### PR TITLE
dictmodel.cpp: fix forgotten free for path

### DIFF
--- a/gui/dictmodel.cpp
+++ b/gui/dictmodel.cpp
@@ -43,6 +43,7 @@ void DictModel::defaults()
     if (f.open(QIODevice::ReadOnly)) {
         load(f);
     }
+    free(path);
 }
 
 void DictModel::load()


### PR DESCRIPTION
これが必要だと思うのだけれどよくわからん！
fcitx_utils_get_fcitx_path_with_filenameは間違いなくfreeが必要だと思う
https://github.com/fcitx/fcitx/blob/0c87840dc7d9460c2cb5feaeefec299d0d3d62ec/src/lib/fcitx-utils/utils.h#L424

QFileがよしなにやってくれるということなのかしら やってくれないと思う